### PR TITLE
Made The Refrence To Peer.js Anonymous

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 	<link rel="stylesheet" type="text/css" href="care.css">
 	<link rel="stylesheet" type="text/css" href="battle.css">
 	<link rel="stylesheet" type="text/css" href="menu.css">
-	<script src="https://unpkg.com/peerjs/dist/peerjs.min.js"></script>
+	<script crossorigin="anonymous" src="https://unpkg.com/peerjs/dist/peerjs.min.js"></script>
 	<script src="module.js"></script>
 	<script src="battle.js"></script>
 	<script src="p2p.js"></script>


### PR DESCRIPTION
If you don't set crossorigin=anonymous, then the website you're linking to can access and create cookies under your site, which can lead to privacy issues for users. So, we set crossorigin=anonymous to prevent this behaviour.